### PR TITLE
refactor(backend): simplify address balance query

### DIFF
--- a/backend/src/core/bitcoin-api/bitcoin-api.schema.ts
+++ b/backend/src/core/bitcoin-api/bitcoin-api.schema.ts
@@ -23,13 +23,15 @@ export const Block = z.object({
   nonce: z.number(),
   bits: z.number(),
   difficulty: z.number(),
-  extras: z.object({
-    totalFees: z.number(),
-    avgFee: z.number(),
-    avgFeeRate: z.number(),
-    feeRange: z.number().array(),
-    coinbaseAddress: z.string(),
-  }).optional(),
+  extras: z
+    .object({
+      totalFees: z.number(),
+      avgFee: z.number(),
+      avgFeeRate: z.number(),
+      feeRange: z.number().array(),
+      coinbaseAddress: z.string(),
+    })
+    .optional(),
 });
 export type Block = z.infer<typeof Block>;
 

--- a/backend/src/modules/bitcoin/address/address.dataloader.ts
+++ b/backend/src/modules/bitcoin/address/address.dataloader.ts
@@ -22,44 +22,6 @@ export class BitcoinAddressLoader implements NestDataLoader<string, Address> {
 }
 export type BitcoinAddressLoaderResponse = DataLoaderResponse<BitcoinAddressLoader>;
 
-export interface BitcoinAddressBalance {
-  satoshi: number;
-  pendingSatoshi: number;
-}
-
-@Injectable()
-export class BitcoinAddressBalanceLoader implements NestDataLoader<string, BitcoinAddressBalance> {
-  private logger = new Logger(BitcoinAddressBalanceLoader.name);
-
-  constructor(private bitcoinApiService: BitcoinApiService) {}
-
-  public getBatchFunction() {
-    return (addresses: string[]) => {
-      this.logger.debug(`Loading bitcoin addresses balance: ${addresses.join(', ')}`);
-      return Promise.all(
-        addresses.map(async (address) => {
-          // XXX: Miners has higher chance of getting this error: Too many unspent transaction outputs (>9000). Contact support to raise limits.
-          const utxos = await this.bitcoinApiService.getAddressTxsUtxo({ address });
-
-          let satoshi = 0;
-          let pendingSatoshi = 0;
-          utxos.forEach((utxo) => {
-            satoshi += utxo.value;
-            if (!utxo.status.confirmed) {
-              pendingSatoshi += utxo.value;
-            }
-          });
-          return {
-            satoshi,
-            pendingSatoshi,
-          };
-        }),
-      );
-    };
-  }
-}
-export type BitcoinAddressBalanceLoaderResponse = DataLoaderResponse<BitcoinAddressBalanceLoader>;
-
 export interface BitcoinAddressTransactionsLoaderProps {
   address: string;
   afterTxid?: string;

--- a/backend/src/modules/bitcoin/address/address.module.ts
+++ b/backend/src/modules/bitcoin/address/address.module.ts
@@ -1,19 +1,10 @@
 import { Module } from '@nestjs/common';
 import { BitcoinApiModule } from 'src/core/bitcoin-api/bitcoin-api.module';
 import { BitcoinAddressResolver } from './address.resolver';
-import {
-  BitcoinAddressLoader,
-  BitcoinAddressBalanceLoader,
-  BitcoinAddressTransactionsLoader,
-} from './address.dataloader';
+import { BitcoinAddressLoader, BitcoinAddressTransactionsLoader } from './address.dataloader';
 
 @Module({
   imports: [BitcoinApiModule],
-  providers: [
-    BitcoinAddressResolver,
-    BitcoinAddressLoader,
-    BitcoinAddressBalanceLoader,
-    BitcoinAddressTransactionsLoader,
-  ],
+  providers: [BitcoinAddressResolver, BitcoinAddressLoader, BitcoinAddressTransactionsLoader],
 })
 export class AddressModule {}

--- a/backend/src/modules/bitcoin/address/address.resolver.ts
+++ b/backend/src/modules/bitcoin/address/address.resolver.ts
@@ -5,8 +5,6 @@ import { BitcoinApiService } from 'src/core/bitcoin-api/bitcoin-api.service';
 import { BitcoinBaseTransaction, BitcoinTransaction } from '../transaction/transaction.model';
 import { BitcoinAddress } from './address.model';
 import {
-  BitcoinAddressBalanceLoader,
-  BitcoinAddressBalanceLoaderResponse,
   BitcoinAddressLoader,
   BitcoinAddressLoaderResponse,
   BitcoinAddressTransactionsLoader,
@@ -21,21 +19,19 @@ export class BitcoinAddressResolver {
   @ResolveField(() => Float)
   public async satoshi(
     @Parent() address: BitcoinAddress,
-    @Loader(BitcoinAddressBalanceLoader)
-    addressBalanceLoader: DataLoader<string, BitcoinAddressBalanceLoaderResponse>,
+    @Loader(BitcoinAddressLoader) addressLoader: DataLoader<string, BitcoinAddressLoaderResponse>,
   ): Promise<number> {
-    const { satoshi } = await addressBalanceLoader.load(address.address);
-    return satoshi;
+    const addressStats = await addressLoader.load(address.address);
+    return addressStats.chain_stats.funded_txo_sum - addressStats.chain_stats.spent_txo_sum;
   }
 
   @ResolveField(() => Float)
   public async pendingSatoshi(
     @Parent() address: BitcoinAddress,
-    @Loader(BitcoinAddressBalanceLoader)
-    addressBalanceLoader: DataLoader<string, BitcoinAddressBalanceLoaderResponse>,
+    @Loader(BitcoinAddressLoader) addressLoader: DataLoader<string, BitcoinAddressLoaderResponse>,
   ): Promise<number> {
-    const { pendingSatoshi } = await addressBalanceLoader.load(address.address);
-    return pendingSatoshi;
+    const addressStats = await addressLoader.load(address.address);
+    return addressStats.mempool_stats.funded_txo_sum - addressStats.mempool_stats.spent_txo_sum;
   }
 
   @ResolveField(() => Float)


### PR DESCRIPTION
## Changes
- Simplify the logic of querying `satoshi` and `pendingSatoshi` in the BitcoinAddress
- Resolves https://github.com/ckb-cell/utxo-stack-explorer/issues/10

## Test

This is a random transaction I picked on the [testnet of mempool.space](https://mempool.space/testnet/tx/b062e7a378e86731a8dae6f1940bd963c020ca4911bc4cb26256b5c77d529087):

GraphQL request:
```graphql
{
  btcTransaction(txid: "b062e7a378e86731a8dae6f1940bd963c020ca4911bc4cb26256b5c77d529087") {
    vout {
      address {
        address
        satoshi
        pendingSatoshi
      }
    }
  }
}
```

Response:
```json
{
  "data": {
    "btcTransaction": {
      "vout": [
        {
          "address": {
            "address": "tb1qc73j0up2l7rfahcj2g3yayccm9rjd5chr0uqyd",
            "satoshi": 11211,
            "pendingSatoshi": 5824
          }
        },
        {
          "address": {
            "address": "tb1qdaprd34l5kmvajgmpcakldu9a7dgtwmlkavh7v",
            "satoshi": 11602902,
            "pendingSatoshi": -6529
          }
        }
      ]
    }
  }
}
```

Screenshots:
![](https://github.com/user-attachments/assets/c653e280-86e2-4bfe-b74d-1be257787234)
![](https://github.com/user-attachments/assets/0f085bb9-defb-4616-8674-b5f271a52559)
