### PR TITLE
refactor(backend): type of BitcoinTransaction.locktime to "Float"

### DIFF
--- a/backend/src/modules/bitcoin/transaction/transaction.model.ts
+++ b/backend/src/modules/bitcoin/transaction/transaction.model.ts
@@ -33,8 +33,8 @@ export class BitcoinTransaction {
   @Field(() => Float)
   size: number;
 
-  @Field(() => Date)
-  locktime: Date;
+  @Field(() => Float)
+  locktime: number;
 
   @Field(() => Float)
   weight: number;
@@ -74,7 +74,7 @@ export class BitcoinTransaction {
         }),
       ),
       size: tx.size,
-      locktime: new Date(tx.locktime),
+      locktime: tx.locktime,
       weight: tx.weight,
       fee: tx.fee,
       feeRate: tx.fee / vSize,

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -174,7 +174,7 @@ type BitcoinTransaction {
   vin: [BitcoinInput!]!
   vout: [BitcoinOutput!]!
   size: Float!
-  locktime: Timestamp!
+  locktime: Float!
   weight: Float!
   fee: Float!
   feeRate: Float!


### PR DESCRIPTION
## Changes
- Change the type of BitcoinTransaction.locktime from "Date" to "Float" (originally from https://github.com/ckb-cell/utxo-stack-explorer/issues/20#issuecomment-2257252983)