### PR TITLE
fix(backend): validation pipes must implement constructor function

### DIFF
--- a/backend/src/pipes/validate-address.pipe.ts
+++ b/backend/src/pipes/validate-address.pipe.ts
@@ -13,9 +13,6 @@ import { Env } from 'src/env';
 
 abstract class BaseValidateAddressPipe implements PipeTransform {
   protected logger = new Logger(this.constructor.name);
-
-  protected constructor(protected configService: ConfigService<Env>) { }
-
   protected abstract validateAddress(value: string): boolean;
   protected abstract getErrorMessage(): string;
 
@@ -31,7 +28,7 @@ abstract class BaseValidateAddressPipe implements PipeTransform {
 @Injectable()
 export class ValidateCkbAddressPipe extends BaseValidateAddressPipe {
   constructor(protected configService: ConfigService<Env>) {
-    super(configService);
+    super();
   }
 
   protected validateAddress(value: string): boolean {
@@ -53,7 +50,7 @@ export class ValidateCkbAddressPipe extends BaseValidateAddressPipe {
 @Injectable()
 export class ValidateBtcAddressPipe extends BaseValidateAddressPipe {
   constructor(protected configService: ConfigService<Env>) {
-    super(configService);
+    super();
   }
 
   protected validateAddress(value: string): boolean {


### PR DESCRIPTION
## Changes
- Validation pipes have not been working properly since aa6206cf, because Nest.js cannot handle service injection normally in abstract classes; forcing validation pipe classes to implement their own constructor functions resolves the issue

## Reproduction

Here's a query for reproduction:
```gql
{
  btcAddress(address: "tb1qlvqalfp8rdnk8z9tzzfc9tr5epz0jv0x8dtrha") {
    satoshi
  }
}
```

The result:
```json
{
  "data": {
    "btcAddress": null
  },
  "errors": [
    {
      "message": "Cannot read properties of undefined (reading 'get')",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "btcAddress"
      ]
    }
  ]
}
```