### PR TITLE
feat: rgbppCoins query supports sorting parameter

### DIFF
--- a/backend/src/core/ckb-explorer/ckb-explorer.interface.ts
+++ b/backend/src/core/ckb-explorer/ckb-explorer.interface.ts
@@ -21,6 +21,15 @@ export enum AddressTransactionSortType {
   TimeDesc = 'time.desc',
 }
 
+export enum TransactionListSortType {
+  TransactionsAsc = 'transactions.asc',
+  TransactionsDesc = 'transactions.desc',
+  AddressCountAsc = 'address_count.asc',
+  AddressCountDesc = 'address_count.desc',
+  CreatedTimeAsc = 'created_time.asc',
+  CreatedTimeDesc = 'created_time.desc',
+}
+
 // https://github.com/nervosnetwork/ckb-explorer/blob/f2b9823e1a1ece1b74901ca3090565d62b251dcd/app/workers/bitcoin_transaction_detect_worker.rb#L123C4-L137C8
 export enum LeapDirection {
   In = 'in',

--- a/backend/src/core/ckb-explorer/ckb-explorer.service.ts
+++ b/backend/src/core/ckb-explorer/ckb-explorer.service.ts
@@ -20,6 +20,7 @@ import {
   XUDTTag,
   Statistics,
   TransactionFeesStatistic,
+  TransactionListSortType,
 } from './ckb-explorer.interface';
 
 type BasePaginationParams = {
@@ -47,6 +48,7 @@ type GetRgbppTransactionsParams = BasePaginationParams & {
 
 type GetXUDTListParams = BasePaginationParams & {
   symbol?: string;
+  sort?: TransactionListSortType;
   tags?: XUDTTag[];
 };
 
@@ -184,6 +186,7 @@ export class CkbExplorerService {
   public async getXUDTList({
     symbol,
     tags,
+    sort,
     page = 1,
     pageSize = 10,
   }: GetXUDTListParams): Promise<PaginatedResponse<XUDT>> {
@@ -195,6 +198,9 @@ export class CkbExplorerService {
     }
     if (tags) {
       params.append('tags', tags.join(','));
+    }
+    if (sort) {
+      params.append('sort', sort);
     }
     const response = await this.request.get(`/v1/xudts?${params.toString()}`);
     return response.data;

--- a/backend/src/modules/rgbpp/coin/coin.model.ts
+++ b/backend/src/modules/rgbpp/coin/coin.model.ts
@@ -1,10 +1,14 @@
 import { toNumber } from 'lodash';
-import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
+import { Field, Float, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { CkbScript } from 'src/modules/ckb/script/script.model';
 import * as CkbExplorer from 'src/core/ckb-explorer/ckb-explorer.interface';
 import { RgbppTransaction } from '../transaction/transaction.model';
 
 export type RgbppBaseCoin = Omit<RgbppCoin, 'transactions'>;
+
+registerEnumType(CkbExplorer.TransactionListSortType, {
+  name: 'TransactionListSortType',
+});
 
 @ObjectType({ description: 'RGB++ Coin' })
 export class RgbppCoin {

--- a/backend/src/modules/rgbpp/coin/coin.resolver.ts
+++ b/backend/src/modules/rgbpp/coin/coin.resolver.ts
@@ -1,21 +1,24 @@
 import { Args, Int, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CkbExplorerService } from 'src/core/ckb-explorer/ckb-explorer.service';
-import { XUDTTag } from 'src/core/ckb-explorer/ckb-explorer.interface';
+import { TransactionListSortType, XUDTTag } from 'src/core/ckb-explorer/ckb-explorer.interface';
 import { RgbppTransaction } from '../transaction/transaction.model';
 import { RgbppBaseCoin, RgbppCoin, RgbppCoinList } from './coin.model';
 
 @Resolver(() => RgbppCoin)
 export class RgbppCoinResolver {
-  constructor(private ckbExplorerService: CkbExplorerService) {}
+  constructor(private ckbExplorerService: CkbExplorerService) { }
 
   @Query(() => RgbppCoinList, { name: 'rgbppCoins' })
   public async coins(
     @Args('page', { type: () => Int, nullable: true }) page: number = 1,
     @Args('pageSize', { type: () => Int, nullable: true }) pageSize: number = 10,
+    @Args('sort', { type: () => TransactionListSortType, nullable: true })
+    sort = TransactionListSortType.TransactionsDesc,
   ): Promise<RgbppCoinList> {
     const response = await this.ckbExplorerService.getXUDTList({
       page,
       pageSize,
+      sort,
       tags: [XUDTTag.RgbppCompatible],
     });
     const coins = response.data.map((coin) => RgbppCoin.from(coin.attributes));

--- a/backend/src/modules/rgbpp/transaction/transaction.resolver.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.resolver.ts
@@ -5,7 +5,10 @@ import {
   CkbRpcTransactionLoader,
   CkbRpcTransactionLoaderType,
 } from 'src/modules/ckb/transaction/transaction.dataloader';
-import { BitcoinBaseTransaction, BitcoinTransaction } from 'src/modules/bitcoin/transaction/transaction.model';
+import {
+  BitcoinBaseTransaction,
+  BitcoinTransaction,
+} from 'src/modules/bitcoin/transaction/transaction.model';
 import { RgbppTransactionService } from './transaction.service';
 import {
   BitcoinTransactionLoader,
@@ -22,7 +25,7 @@ import { RgbppTransactionLoader, RgbppTransactionLoaderType } from './transactio
 
 @Resolver(() => RgbppTransaction)
 export class RgbppTransactionResolver {
-  constructor(private transactionService: RgbppTransactionService) {}
+  constructor(private transactionService: RgbppTransactionService) { }
 
   @Query(() => RgbppLatestTransactionList, { name: 'rgbppLatestTransactions' })
   public async getLatestTransactions(

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -289,8 +289,17 @@ type Query {
   rgbppTransaction(txidOrTxHash: String!): RgbppTransaction
   btcAddress(address: String!): BitcoinAddress
   rgbppAddress(address: String!): RgbppAddress
-  rgbppCoins(page: Int, pageSize: Int): RgbppCoinList!
+  rgbppCoins(page: Int, pageSize: Int, sort: TransactionListSortType): RgbppCoinList!
   rgbppCoin(typeHash: String!): RgbppCoin!
   rgbppStatistic: RgbppStatistic!
   search(query: String!): SearchResult!
+}
+
+enum TransactionListSortType {
+  TransactionsAsc
+  TransactionsDesc
+  AddressCountAsc
+  AddressCountDesc
+  CreatedTimeAsc
+  CreatedTimeDesc
 }


### PR DESCRIPTION
rgbppCoins query supports sorting parameter, and the default sorting is in desc order of latest 24 hours transaction count