### PR TITLE
fix: fix getTxOutSpends schema struct

### DIFF
--- a/backend/src/core/bitcoin-api/bitcoin-api.schema.ts
+++ b/backend/src/core/bitcoin-api/bitcoin-api.schema.ts
@@ -114,19 +114,22 @@ export const Transaction = z.object({
 });
 export type Transaction = z.infer<typeof Transaction>;
 
-export const OutSpend = z.object({
-  spent: z.boolean(),
-  txid: z.string().optional(),
-  vin: z.number().optional(),
-  status: z
-    .object({
+export const OutSpend = z.discriminatedUnion('spent', [
+  z.object({
+    spent: z.literal(false),
+  }),
+  z.object({
+    spent: z.literal(true),
+    txid: z.string(),
+    vin: z.number(),
+    status: z.object({
       confirmed: z.boolean(),
-      block_height: z.number(),
-      block_hash: z.string(),
-      block_time: z.number(),
-    })
-    .optional(),
-});
+      block_height: z.number().optional(),
+      block_hash: z.string().optional(),
+      block_time: z.number().optional(),
+    }),
+  }),
+]);
 export type OutSpend = z.infer<typeof OutSpend>;
 
 export const RecommendedFees = z.object({


### PR DESCRIPTION
fix sentry issue: https://sentry-pro.mail3.land/organizations/sentry/issues/7785/?environment=production&project=15

## Bad Case
```json
{
    "spent": true,
    "txid": "29005e8e27058bc53031aefde925332d41c13ca7b98d7a3b66665275bf7820be",
    "vin": 0,
    "status": {
      "confirmed": false
    }
  }
```