### PR TITLE
chore: enable Cors

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -7,6 +7,17 @@ export const envSchema = z
     NETWORK: z.enum([NetworkType.mainnet, NetworkType.testnet]).default(NetworkType.testnet),
     ENABLED_GRAPHQL_PLAYGROUND: z.boolean().default(true),
 
+    /**
+     * CORS origin whitelist (split by comma)
+     */
+    CORS_WHITELIST: z
+      .string()
+      .default('')
+      .transform((value) => {
+        const origin = value.split(',');
+        return origin.map((host) => host.trim());
+      }),
+
     // DATABASE_URL: z.string(),
     REDIS_URL: z.string(),
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,14 +1,20 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify';
+import { envSchema } from './env';
+
+const env = envSchema.parse(process.env);
 
 async function bootstrap() {
   const app = await NestFactory.create<NestFastifyApplication>(AppModule, new FastifyAdapter());
-  app.enableCors({
-    origin: ['https://explorer.utxostack.network', 'http://explorer.utxostack.network','http://localhost:3000'],
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-    credentials: true,
-  });
+
+  if (env.CORS_WHITELIST.length > 0) {
+    app.enableCors({
+      origin: env.CORS_WHITELIST,
+      methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+      credentials: true,
+    });
+  }
   await app.listen(3000, '0.0.0.0');
 }
 bootstrap();


### PR DESCRIPTION
Env Example：
`CORS_WHITELIST=https://explorer.utxostack.network/,http://localhost:3000`