### PR TITLE
fix: fix btc time lock rgbpp transaction query

### DIFF
--- a/backend/src/modules/rgbpp/transaction/transaction.service.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.service.ts
@@ -12,17 +12,6 @@ import { Env } from 'src/env';
 import { CkbRpcWebsocketService } from 'src/core/ckb-rpc/ckb-rpc-websocket.service';
 import { buildRgbppLockArgs, genRgbppLockScript } from '@rgbpp-sdk/ckb/lib/utils/rgbpp';
 import * as BitcoinApiInterface from 'src/core/bitcoin-api/bitcoin-api.schema';
-import {
-  getBtcTimeLockScript,
-  isScriptEqual,
-  remove0x,
-  btcTxIdAndAfterFromBtcTimeLockArgs,
-} from '@rgbpp-sdk/ckb';
-import { SearchKey } from 'src/core/ckb-rpc/ckb-rpc.interface';
-import * as pLimit from 'p-limit';
-import { BI, HashType } from '@ckb-lumos/lumos';
-
-const limit = pLimit(100);
 
 @Injectable()
 export class RgbppTransactionService {


### PR DESCRIPTION
The previously implemented RGB++ transaction query logic omitted the BTCTimeLock transaction of L1 -> L2, resulting in the inability to return the RGB++ related CKB transaction.

The PR realizes the search for the CKB transaction containing BTCTimeLock Cell through BTC txid. 

The implementation is as follows:
- Get BTC transaction through txid
- Use CKB RPC to query the CKB transaction corresponding to the input containing the BTC transaction
  - For any RgbppLock cell, there are up to two transactions on CKB that contain it. One may be an L2->L1/L1->L1 transaction, and the other may be an L1->L1/L1-> L2 transaction.
  - We can determine which transaction they are by parsing the input/output cell lock script of these two transactions.
  - In this PR, we use the CKB Explorer API to simplify the process
- Get the details of the CKB transaction and determine whether it contains BTCTimeLock Cell output
- Build `RgbppTransaction` through CKB transactions