### PR TITLE
fix: fix ckb block totalFees field, return null when the block is just mined

### DIFF
--- a/backend/src/core/ckb-rpc/ckb-rpc-websocket.service.ts
+++ b/backend/src/core/ckb-rpc/ckb-rpc-websocket.service.ts
@@ -57,13 +57,16 @@ export class CkbRpcWebsocketService {
     key: (blockHash: string) => `getBlock:${blockHash}`,
     ttl: ONE_MONTH_MS,
     shouldCache: async (block: Block, that: CkbRpcWebsocketService) => {
+      if (!block?.header) {
+        return false;
+      }
       const { number } = block.header;
       return that.isSafeConfirmations(number);
     },
   })
   public async getBlock(blockHash: string): Promise<Block> {
     this.logger.debug(`get_block - blockHash: ${blockHash}`);
-    const block = await this.websocket.call('get_block', [blockHash]);
+    let block = await this.websocket.call('get_block', [blockHash]);
     return block as Block;
   }
 

--- a/backend/src/modules/ckb/block/block.model.ts
+++ b/backend/src/modules/ckb/block/block.model.ts
@@ -25,8 +25,8 @@ export class CkbBlock {
   @Field(() => Int)
   transactionsCount: number;
 
-  @Field(() => Float)
-  totalFee: number;
+  @Field(() => Float, { nullable: true })
+  totalFee: number | null;
 
   @Field(() => CkbAddress)
   miner: CkbAddress;

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -67,7 +67,7 @@ type CkbBlock {
   number: Int!
   timestamp: Timestamp!
   transactionsCount: Int!
-  totalFee: Float!
+  totalFee: Float
   miner: CkbAddress!
   reward: Float!
   transactions: [CkbTransaction!]!


### PR DESCRIPTION
When querying the latest block, CKB RPC may return null `totalFees`.
the PR which allows the totalFees field to return null to ensure that the query can return normally.