### PR TITLE
fix: fix model and resolver consistency by remove base model interface

### DIFF
--- a/backend/src/modules/bitcoin/address/address.resolver.ts
+++ b/backend/src/modules/bitcoin/address/address.resolver.ts
@@ -1,6 +1,6 @@
 import { Loader } from '@applifting-io/nestjs-dataloader';
 import { Args, Float, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { RgbppAddress, RgbppBaseAddress } from 'src/modules/rgbpp/address/address.model';
+import { RgbppAddress } from 'src/modules/rgbpp/address/address.model';
 import { BitcoinBaseTransaction, BitcoinTransaction } from '../transaction/transaction.model';
 import { BitcoinAddress, BitcoinBaseAddress } from './address.model';
 import {
@@ -72,7 +72,7 @@ export class BitcoinAddressResolver {
   }
 
   @ResolveField(() => RgbppAddress)
-  public async rgbppAddress(@Parent() address: BitcoinBaseAddress): Promise<RgbppBaseAddress> {
+  public async rgbppAddress(@Parent() address: BitcoinBaseAddress): Promise<RgbppAddress> {
     return RgbppAddress.from(address.address);
   }
 }

--- a/backend/src/modules/bitcoin/transaction/transaction.resolver.ts
+++ b/backend/src/modules/bitcoin/transaction/transaction.resolver.ts
@@ -3,10 +3,7 @@ import { Args, Float, Parent, Query, ResolveField, Resolver } from '@nestjs/grap
 import { BitcoinApiService } from 'src/core/bitcoin-api/bitcoin-api.service';
 import { BitcoinBaseTransaction, BitcoinTransaction } from './transaction.model';
 import { BitcoinTransactionLoader, BitcoinTransactionLoaderType } from './transaction.dataloader';
-import {
-  RgbppBaseTransaction,
-  RgbppTransaction,
-} from 'src/modules/rgbpp/transaction/transaction.model';
+import { RgbppTransaction } from 'src/modules/rgbpp/transaction/transaction.model';
 import {
   RgbppTransactionLoader,
   RgbppTransactionLoaderType,
@@ -16,7 +13,7 @@ import { BitcoinBlockLoader, BitcoinBlockLoaderType } from '../block/dataloader/
 
 @Resolver(() => BitcoinTransaction)
 export class BitcoinTransactionResolver {
-  constructor(private bitcoinApiService: BitcoinApiService) {}
+  constructor(private bitcoinApiService: BitcoinApiService) { }
 
   @Query(() => BitcoinTransaction, { name: 'btcTransaction', nullable: true })
   public async getTransaction(
@@ -67,7 +64,7 @@ export class BitcoinTransactionResolver {
   public async rgbppTransaction(
     @Parent() tx: BitcoinBaseTransaction,
     @Loader(RgbppTransactionLoader) txLoader: RgbppTransactionLoaderType,
-  ): Promise<RgbppBaseTransaction | null> {
+  ): Promise<RgbppTransaction | null> {
     const result = await txLoader.load(tx.txid);
     return result || null;
   }

--- a/backend/src/modules/ckb/address/address.model.ts
+++ b/backend/src/modules/ckb/address/address.model.ts
@@ -1,7 +1,4 @@
-import { Field, Float, ObjectType } from '@nestjs/graphql';
-import { CkbTransaction } from '../transaction/transaction.model';
-
-export type CkbBaseAddress = Pick<CkbAddress, 'address'>;
+import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType({ description: 'CKB Address Balance' })
 export class CkbAddressBalance {
@@ -20,19 +17,7 @@ export class CkbAddress {
   @Field(() => String)
   address: string;
 
-  @Field(() => Float)
-  shannon: number;
-
-  @Field(() => Float)
-  transactionsCount: number;
-
-  @Field(() => [CkbTransaction])
-  transactions: CkbTransaction[];
-
-  @Field(() => CkbAddressBalance)
-  balance: CkbAddressBalance;
-
-  public static from(address: string): CkbBaseAddress {
+  public static from(address: string): CkbAddress {
     return {
       address,
     };

--- a/backend/src/modules/ckb/address/address.resolver.ts
+++ b/backend/src/modules/ckb/address/address.resolver.ts
@@ -1,7 +1,7 @@
 import { Loader } from '@applifting-io/nestjs-dataloader';
 import { Args, Float, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { CkbBaseTransaction, CkbTransaction } from '../transaction/transaction.model';
-import { CkbAddress, CkbAddressBalance, CkbBaseAddress } from './address.model';
+import { CkbTransaction } from '../transaction/transaction.model';
+import { CkbAddressBalance, CkbAddress } from './address.model';
 import {
   CkbAddressLoader,
   CkbAddressLoaderType,
@@ -20,7 +20,7 @@ export class CkbAddressResolver {
   @Query(() => CkbAddress, { name: 'ckbAddress', nullable: true })
   public async getCkbAddress(
     @Args('address', ValidateCkbAddressPipe) address: string,
-  ): Promise<CkbBaseAddress> {
+  ): Promise<CkbAddress> {
     return {
       address,
     };
@@ -28,7 +28,7 @@ export class CkbAddressResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async shannon(
-    @Parent() address: CkbBaseAddress,
+    @Parent() address: CkbAddress,
     @Loader(CkbAddressLoader) addressLoader: CkbAddressLoaderType,
   ): Promise<number | null> {
     const addressInfo = await addressLoader.load({ address: address.address });
@@ -40,7 +40,7 @@ export class CkbAddressResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async transactionsCount(
-    @Parent() address: CkbBaseAddress,
+    @Parent() address: CkbAddress,
     @Loader(CkbAddressLoader) addressLoader: CkbAddressLoaderType,
   ): Promise<number | null> {
     const addressInfo = await addressLoader.load({ address: address.address });
@@ -52,12 +52,12 @@ export class CkbAddressResolver {
 
   @ResolveField(() => [CkbTransaction], { nullable: true })
   public async transactions(
-    @Parent() address: CkbBaseAddress,
+    @Parent() address: CkbAddress,
     @Loader(CkbAddressTransactionsLoader) addressTxsLoader: CkbAddressTransactionsLoaderType,
     @Loader(CkbRpcTransactionLoader) rpcTxLoader: CkbRpcTransactionLoaderType,
     @Args('page', { nullable: true }) page?: number,
     @Args('pageSize', { nullable: true }) pageSize?: number,
-  ): Promise<(CkbBaseTransaction | null)[] | null> {
+  ): Promise<(CkbTransaction | null)[] | null> {
     const res = await addressTxsLoader.load({
       address: address.address,
       pageSize,
@@ -79,7 +79,7 @@ export class CkbAddressResolver {
 
   @ResolveField(() => CkbAddressBalance, { nullable: true })
   public async balance(
-    @Parent() address: CkbBaseAddress,
+    @Parent() address: CkbAddress,
     @Loader(CkbAddressLoader) addressLoader: CkbAddressLoaderType,
   ): Promise<CkbAddressBalance | null> {
     const addressInfo = await addressLoader.load({ address: address.address });

--- a/backend/src/modules/ckb/block/block.model.ts
+++ b/backend/src/modules/ckb/block/block.model.ts
@@ -1,13 +1,6 @@
 import { toNumber } from 'lodash';
-import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
+import { Field, Int, ObjectType } from '@nestjs/graphql';
 import * as CkbRpc from 'src/core/ckb-rpc/ckb-rpc.interface';
-import { CkbAddress } from '../address/address.model';
-import { CkbTransaction } from '../transaction/transaction.model';
-
-export type CkbBaseBlock = Omit<
-  CkbBlock,
-  'totalFee' | 'feeRateRange' | 'miner' | 'reward' | 'transactions' | 'size' | 'confirmations'
->;
 
 @ObjectType({ description: 'CKB Block' })
 export class CkbBlock {
@@ -19,31 +12,14 @@ export class CkbBlock {
 
   @Field(() => Int)
   number: number;
+
   @Field(() => Date)
   timestamp: Date;
 
   @Field(() => Int)
   transactionsCount: number;
 
-  @Field(() => Float, { nullable: true })
-  totalFee: number | null;
-
-  @Field(() => CkbAddress)
-  miner: CkbAddress;
-
-  @Field(() => Float)
-  reward: number;
-
-  @Field(() => [CkbTransaction])
-  transactions: CkbTransaction[];
-
-  @Field(() => Float, { nullable: true })
-  size: number | null;
-
-  @Field(() => Float, { nullable: true })
-  confirmations: number | null;
-
-  public static from(block: CkbRpc.Block): CkbBaseBlock {
+  public static from(block: CkbRpc.Block): CkbBlock {
     return {
       version: toNumber(block.header.version),
       hash: block.header.hash,

--- a/backend/src/modules/ckb/block/block.resolver.ts
+++ b/backend/src/modules/ckb/block/block.resolver.ts
@@ -2,9 +2,9 @@ import { BI } from '@ckb-lumos/bi';
 import { toNumber } from 'lodash';
 import { Loader } from '@applifting-io/nestjs-dataloader';
 import { Args, Float, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { CkbBaseTransaction, CkbTransaction } from '../transaction/transaction.model';
-import { CkbAddress, CkbBaseAddress } from '../address/address.model';
-import { CkbBlock, CkbBaseBlock } from './block.model';
+import { CkbTransaction } from '../transaction/transaction.model';
+import { CkbAddress } from '../address/address.model';
+import { CkbBlock } from './block.model';
 import {
   CkbBlockEconomicStateLoader,
   CkbBlockEconomicStateLoaderType,
@@ -27,7 +27,7 @@ export class CkbBlockResolver {
   public async getBlock(
     @Args('heightOrHash', { type: () => String }) heightOrHash: string,
     @Loader(CkbRpcBlockLoader) rpcBlockLoader: CkbRpcBlockLoaderType,
-  ): Promise<CkbBaseBlock | null> {
+  ): Promise<CkbBlock | null> {
     const block = await rpcBlockLoader.load(heightOrHash);
     if (!block) {
       return null;
@@ -37,7 +37,7 @@ export class CkbBlockResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async totalFee(
-    @Parent() block: CkbBaseBlock,
+    @Parent() block: CkbBlock,
     @Loader(CkbBlockEconomicStateLoader) blockEconomicLoader: CkbBlockEconomicStateLoaderType,
   ): Promise<number | null> {
     const blockEconomicState = await blockEconomicLoader.load(block.hash);
@@ -49,9 +49,9 @@ export class CkbBlockResolver {
 
   @ResolveField(() => CkbAddress, { nullable: true })
   public async miner(
-    @Parent() block: CkbBaseBlock,
+    @Parent() block: CkbBlock,
     @Loader(CkbExplorerBlockLoader) explorerBlockLoader: CkbExplorerBlockLoaderType,
-  ): Promise<CkbBaseAddress | null> {
+  ): Promise<CkbAddress | null> {
     const explorerBlock = await explorerBlockLoader.load(block.hash);
     if (!explorerBlock) {
       return null;
@@ -61,7 +61,7 @@ export class CkbBlockResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async reward(
-    @Parent() block: CkbBaseBlock,
+    @Parent() block: CkbBlock,
     @Loader(CkbExplorerBlockLoader) explorerBlockLoader: CkbExplorerBlockLoaderType,
   ): Promise<number | null> {
     const explorerBlock = await explorerBlockLoader.load(block.hash);
@@ -71,12 +71,12 @@ export class CkbBlockResolver {
     return toNumber(explorerBlock.miner_reward);
   }
 
-  @ResolveField(() => [String], { nullable: true })
+  @ResolveField(() => [CkbTransaction], { nullable: true })
   public async transactions(
-    @Parent() { hash }: CkbBaseBlock,
+    @Parent() { hash }: CkbBlock,
     @Loader(CkbRpcBlockLoader) rpcBlockLoader: CkbRpcBlockLoaderType,
     @Loader(CkbRpcTransactionLoader) rpcTxLoader: CkbRpcTransactionLoaderType,
-  ): Promise<(CkbBaseTransaction | null)[] | null> {
+  ): Promise<(CkbTransaction | null)[] | null> {
     const block = await rpcBlockLoader.load(hash);
     if (!block) {
       return null;
@@ -94,7 +94,7 @@ export class CkbBlockResolver {
 
   @ResolveField(() => Float)
   public async size(
-    @Parent() block: CkbBaseBlock,
+    @Parent() block: CkbBlock,
     @Loader(CkbExplorerBlockLoader) explorerBlockLoader: CkbExplorerBlockLoaderType,
   ): Promise<number | null> {
     const explorerBlock = await explorerBlockLoader.load(block.hash);
@@ -106,7 +106,7 @@ export class CkbBlockResolver {
 
   @ResolveField(() => Float)
   public async confirmations(
-    @Parent() block: CkbBaseBlock,
+    @Parent() block: CkbBlock,
     @Loader(CkbExplorerBlockLoader) explorerBlockLoader: CkbExplorerBlockLoaderType,
   ): Promise<number | null> {
     const tipBlockNumber = await this.ckbRpcService.getTipBlockNumber();

--- a/backend/src/modules/ckb/cell/cell.model.ts
+++ b/backend/src/modules/ckb/cell/cell.model.ts
@@ -1,7 +1,7 @@
 import { toNumber } from 'lodash';
 import { Field, Float, Int, ObjectType } from '@nestjs/graphql';
 import * as CkbRpc from 'src/core/ckb-rpc/ckb-rpc.interface';
-import { CellType, CkbScript } from '../script/script.model';
+import { CkbScript } from '../script/script.model';
 
 @ObjectType({ description: 'CKB XUDT Info' })
 export class CkbXUDTInfo {
@@ -18,8 +18,6 @@ export class CkbXUDTInfo {
   typeHash: string;
 }
 
-export type CkbBaseCellStatus = Omit<CkbCellStatus, 'txHash' | 'index'>;
-
 @ObjectType({ description: 'CKB Cell Status' })
 export class CkbCellStatus {
   @Field(() => Boolean)
@@ -31,8 +29,6 @@ export class CkbCellStatus {
   @Field(() => Float, { nullable: true })
   index: number | null;
 }
-
-export type CkbBaseCell = Omit<CkbCell, 'xudtInfo' | 'status' | 'cellType'>;
 
 @ObjectType({ description: 'CKB Cell' })
 export class CkbCell {
@@ -51,16 +47,7 @@ export class CkbCell {
   @Field(() => CkbScript)
   lock: CkbScript;
 
-  @Field(() => CkbXUDTInfo, { nullable: true })
-  xudtInfo: CkbXUDTInfo | null;
-
-  @Field(() => CkbCellStatus)
-  status: CkbCellStatus;
-
-  @Field(() => CellType, { nullable: true })
-  cellType: CellType | null;
-
-  public static fromTransaction(tx: CkbRpc.Transaction, index: number): CkbBaseCell {
+  public static fromTransaction(tx: CkbRpc.Transaction, index: number): CkbCell {
     const output = tx.outputs[index];
     return {
       txHash: tx.hash,
@@ -71,7 +58,7 @@ export class CkbCell {
     };
   }
 
-  public static fromCell(cell: CkbRpc.Cell): CkbBaseCell {
+  public static fromCell(cell: CkbRpc.Cell): CkbCell {
     return {
       txHash: cell.out_point.tx_hash,
       index: toNumber(cell.out_point.index),

--- a/backend/src/modules/ckb/cell/cell.resolver.ts
+++ b/backend/src/modules/ckb/cell/cell.resolver.ts
@@ -7,7 +7,7 @@ import {
   CkbRpcTransactionLoader,
   CkbRpcTransactionLoaderType,
 } from '../transaction/transaction.dataloader';
-import { CkbCell, CkbXUDTInfo, CkbBaseCellStatus, CkbCellStatus, CkbBaseCell } from './cell.model';
+import { CkbCell, CkbXUDTInfo, CkbCellStatus } from './cell.model';
 import { CkbCellService } from './cell.service';
 import { CellType } from '../script/script.model';
 import { CkbScriptService } from '../script/script.service';
@@ -21,7 +21,7 @@ export class CkbCellResolver {
 
   @ResolveField(() => CkbXUDTInfo, { nullable: true })
   public async xudtInfo(
-    @Parent() cell: CkbBaseCell,
+    @Parent() cell: CkbCell,
     @Loader(CkbExplorerTransactionLoader) explorerTxLoader: CkbExplorerTransactionLoaderType,
   ): Promise<CkbXUDTInfo | null> {
     const tx = await explorerTxLoader.load(cell.txHash);
@@ -34,10 +34,10 @@ export class CkbCellResolver {
 
   @ResolveField(() => CkbCellStatus, { nullable: true })
   public async status(
-    @Parent() cell: CkbBaseCell,
+    @Parent() cell: CkbCell,
     @Loader(CkbRpcTransactionLoader) rpcTxLoader: CkbRpcTransactionLoaderType,
     @Loader(CkbExplorerTransactionLoader) explorerTxLoader: CkbExplorerTransactionLoaderType,
-  ): Promise<CkbCellStatus | CkbBaseCellStatus | null> {
+  ): Promise<CkbCellStatus | CkbCellStatus | null> {
     const tx = await explorerTxLoader.load(cell.txHash);
     if (!tx || !tx.display_outputs[cell.index]) {
       return null;
@@ -62,12 +62,14 @@ export class CkbCellResolver {
     } else {
       return {
         consumed,
+        txHash: null,
+        index: null,
       };
     }
   }
 
   @ResolveField(() => CellType, { nullable: true })
-  public cellType(@Parent() cell: CkbBaseCell) {
+  public cellType(@Parent() cell: CkbCell) {
     if (!cell.type) {
       return null;
     }

--- a/backend/src/modules/ckb/cell/cell.service.ts
+++ b/backend/src/modules/ckb/cell/cell.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@nestjs/common';
 import * as CkbExplorer from 'src/core/ckb-explorer/ckb-explorer.interface';
-import { CkbBaseCell, CkbXUDTInfo } from './cell.model';
+import { CkbCell, CkbXUDTInfo } from './cell.model';
 import { BI, Script } from '@ckb-lumos/lumos';
 import { computeScriptHash } from '@ckb-lumos/lumos/utils';
 
 @Injectable()
 export class CkbCellService {
   public getXUDTInfoFromOutput(
-    cell: CkbBaseCell,
+    cell: CkbCell,
     output: CkbExplorer.DisplayOutput,
   ): CkbXUDTInfo | null {
     const info = output.xudt_info || output.omiga_inscription_info;

--- a/backend/src/modules/ckb/ckb.model.ts
+++ b/backend/src/modules/ckb/ckb.model.ts
@@ -12,16 +12,8 @@ export class CkbFees {
   average: number;
 }
 
-export type CkbBaseChainInfo = Omit<CkbChainInfo, 'fees' | 'transactionsCountIn24Hours'>;
-
 @ObjectType({ description: 'CKB ChainInfo' })
 export class CkbChainInfo {
   @Field(() => Float)
   tipBlockNumber: number;
-
-  @Field(() => Float)
-  transactionsCountIn24Hours: number;
-
-  @Field(() => CkbFees)
-  fees: CkbFees;
 }

--- a/backend/src/modules/ckb/ckb.resolver.ts
+++ b/backend/src/modules/ckb/ckb.resolver.ts
@@ -2,7 +2,7 @@ import { toNumber } from 'lodash';
 import { Float, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CkbRpcWebsocketService } from 'src/core/ckb-rpc/ckb-rpc-websocket.service';
 import { CkbExplorerService } from 'src/core/ckb-explorer/ckb-explorer.service';
-import { CkbBaseChainInfo, CkbChainInfo, CkbFees } from './ckb.model';
+import { CkbChainInfo, CkbFees } from './ckb.model';
 import { CkbService } from './ckb.service';
 import { calcFeeRate, getWeightedMedian } from 'src/common/fee-rate';
 
@@ -15,7 +15,7 @@ export class CkbResolver {
   ) { }
 
   @Query(() => CkbChainInfo, { name: 'ckbChainInfo' })
-  public async chainInfo(): Promise<CkbBaseChainInfo> {
+  public async chainInfo(): Promise<CkbChainInfo> {
     const tipBlockNumber = await this.ckbRpcService.getTipBlockNumber();
     return {
       tipBlockNumber,

--- a/backend/src/modules/ckb/transaction/transaction.model.ts
+++ b/backend/src/modules/ckb/transaction/transaction.model.ts
@@ -3,14 +3,8 @@ import { Field, Float, InputType, ObjectType } from '@nestjs/graphql';
 import { ResultFormatter, RPCTypes } from '@ckb-lumos/lumos/rpc';
 import { blockchain } from '@ckb-lumos/lumos/codec';
 import * as CkbRpc from 'src/core/ckb-rpc/ckb-rpc.interface';
-import { CkbBaseCell, CkbCell } from '../cell/cell.model';
-import { CkbBlock } from '../block/block.model';
+import { CkbCell } from '../cell/cell.model';
 import { CkbScriptInput } from '../script/script.model';
-
-export type CkbBaseTransaction = Omit<
-  CkbTransaction,
-  'block' | 'inputs' | 'fee' | 'feeRate' | 'confirmations'
->;
 
 @InputType({ description: 'Search key for CKB transactions' })
 export class CkbSearchKeyInput {
@@ -33,32 +27,17 @@ export class CkbTransaction {
   hash: string;
 
   @Field(() => Float)
-  fee: number;
-
-  @Field(() => Float)
-  feeRate: number;
-
-  @Field(() => Float)
   size: number;
 
   @Field(() => [CkbCell])
-  inputs: CkbBaseCell[];
-
-  @Field(() => [CkbCell])
-  outputs: CkbBaseCell[];
-
-  @Field(() => CkbBlock)
-  block: CkbBlock;
+  outputs: CkbCell[];
 
   @Field(() => Boolean)
   confirmed: boolean;
 
-  @Field(() => Float)
-  confirmations: number;
-
   public static from(
     transactionWithStatus: CkbRpc.TransactionWithStatusResponse,
-  ): CkbBaseTransaction | null {
+  ): CkbTransaction | null {
     const { transaction, tx_status } = transactionWithStatus;
     if (!transaction || tx_status?.status === 'unknown') {
       return null;

--- a/backend/src/modules/ckb/transaction/transaction.resolver.ts
+++ b/backend/src/modules/ckb/transaction/transaction.resolver.ts
@@ -3,10 +3,10 @@ import { toNumber } from 'lodash';
 import { Loader } from '@applifting-io/nestjs-dataloader';
 import { Args, Float, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CkbRpcBlockLoader, CkbRpcBlockLoaderType } from '../block/block.dataloader';
-import { CkbBaseBlock, CkbBlock } from '../block/block.model';
-import { CkbBaseCell, CkbCell } from '../cell/cell.model';
+import { CkbBlock } from '../block/block.model';
+import { CkbCell } from '../cell/cell.model';
 import { CkbTransactionService } from './transaction.service';
-import { CkbTransaction, CkbBaseTransaction, CkbSearchKeyInput } from './transaction.model';
+import { CkbTransaction, CkbSearchKeyInput } from './transaction.model';
 import {
   CkbRpcTransactionLoader,
   CkbRpcTransactionLoaderType,
@@ -38,7 +38,7 @@ export class CkbTransactionResolver {
     @Args('limit', { type: () => Float, nullable: true }) limit: number = 10,
     @Args('order', { type: () => OrderType, nullable: true }) order: OrderType = OrderType.Desc,
     @Args('after', { type: () => String, nullable: true }) after: string | null,
-  ): Promise<CkbBaseTransaction[]> {
+  ): Promise<CkbTransaction[]> {
     if (types && scriptKey) {
       throw new BadRequestException('Only one of types and scriptKey can be provided');
     }
@@ -97,7 +97,7 @@ export class CkbTransactionResolver {
   public async getTransaction(
     @Args('txHash') txHash: string,
     @Loader(CkbRpcTransactionLoader) rpcTxLoader: CkbRpcTransactionLoaderType,
-  ): Promise<CkbBaseTransaction | null> {
+  ): Promise<CkbTransaction | null> {
     const tx = await rpcTxLoader.load(txHash);
     if (!tx) {
       return null;
@@ -107,9 +107,9 @@ export class CkbTransactionResolver {
 
   @ResolveField(() => [CkbCell], { nullable: true })
   public async inputs(
-    @Parent() tx: CkbBaseTransaction,
+    @Parent() tx: CkbTransaction,
     @Loader(CkbRpcTransactionLoader) rpcTxLoader: CkbRpcTransactionLoaderType,
-  ): Promise<(CkbBaseCell | null)[] | null> {
+  ): Promise<(CkbCell | null)[] | null> {
     const rpcTx = await rpcTxLoader.load(tx.hash);
     if (!rpcTx) {
       return null;
@@ -132,9 +132,9 @@ export class CkbTransactionResolver {
 
   @ResolveField(() => CkbBlock, { nullable: true })
   public async block(
-    @Parent() tx: CkbBaseTransaction,
+    @Parent() tx: CkbTransaction,
     @Loader(CkbRpcBlockLoader) rpcBlockLoader: CkbRpcBlockLoaderType,
-  ): Promise<CkbBaseBlock | null> {
+  ): Promise<CkbBlock | null> {
     const block = await rpcBlockLoader.load(tx.blockNumber.toString());
     if (!block) {
       return null;
@@ -144,7 +144,7 @@ export class CkbTransactionResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async fee(
-    @Parent() tx: CkbBaseTransaction,
+    @Parent() tx: CkbTransaction,
     @Loader(CkbExplorerTransactionLoader) explorerTxLoader: CkbExplorerTransactionLoaderType,
   ): Promise<number | null> {
     const explorerTx = await explorerTxLoader.load(tx.hash);
@@ -156,7 +156,7 @@ export class CkbTransactionResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async feeRate(
-    @Parent() tx: CkbBaseTransaction,
+    @Parent() tx: CkbTransaction,
     @Loader(CkbExplorerTransactionLoader) explorerTxLoader: CkbExplorerTransactionLoaderType,
   ): Promise<number | null> {
     const explorerTx = await explorerTxLoader.load(tx.hash);
@@ -170,7 +170,7 @@ export class CkbTransactionResolver {
   }
 
   @ResolveField(() => Float)
-  public async confirmations(@Parent() tx: CkbBaseTransaction): Promise<number> {
+  public async confirmations(@Parent() tx: CkbTransaction): Promise<number> {
     if (!tx.confirmed) {
       return 0;
     }

--- a/backend/src/modules/rgbpp/address/address.model.ts
+++ b/backend/src/modules/rgbpp/address/address.model.ts
@@ -1,27 +1,11 @@
-import { Field, Float, ObjectType } from '@nestjs/graphql';
-import { RgbppAsset } from '../asset/asset.model';
-import { CkbXUDTInfo } from 'src/modules/ckb/cell/cell.model';
-
-export type RgbppBaseAddress = Pick<RgbppAddress, 'address'>;
+import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType({ description: 'Rgbpp Address' })
 export class RgbppAddress {
   @Field(() => String)
   address: string;
 
-  @Field(() => Float)
-  utxosCount: number;
-
-  @Field(() => Float)
-  cellsCount: number;
-
-  @Field(() => [RgbppAsset])
-  assets: RgbppAsset[];
-
-  @Field(() => [CkbXUDTInfo])
-  balances: CkbXUDTInfo[];
-
-  public static from(address: string): RgbppBaseAddress {
+  public static from(address: string): RgbppAddress {
     return {
       address,
     };

--- a/backend/src/modules/rgbpp/address/address.resolver.ts
+++ b/backend/src/modules/rgbpp/address/address.resolver.ts
@@ -1,9 +1,9 @@
 import { Args, Float, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CkbExplorerService } from 'src/core/ckb-explorer/ckb-explorer.service';
-import { RgbppAddress, RgbppBaseAddress } from './address.model';
+import { RgbppAddress } from './address.model';
 import { RgbppAddressService } from './address.service';
 import { ParentField } from 'src/decorators/parent-field.decorator';
-import { RgbppAsset, RgbppBaseAsset } from '../asset/asset.model';
+import { RgbppAsset } from '../asset/asset.model';
 import { CkbXUDTInfo } from 'src/modules/ckb/cell/cell.model';
 import * as pLimit from 'p-limit';
 import { Loader } from '@applifting-io/nestjs-dataloader';
@@ -20,10 +20,10 @@ export class RgbppAddressResolver {
   constructor(
     private ckbExplorerService: CkbExplorerService,
     private rgbppAddressService: RgbppAddressService,
-  ) {}
+  ) { }
 
   @Query(() => RgbppAddress, { name: 'rgbppAddress', nullable: true })
-  public async getBtcAddress(@Args('address') address: string): Promise<RgbppBaseAddress> {
+  public async getBtcAddress(@Args('address') address: string): Promise<RgbppAddress> {
     return RgbppAddress.from(address);
   }
 
@@ -42,12 +42,12 @@ export class RgbppAddressResolver {
   }
 
   @ResolveField(() => [RgbppAsset])
-  public async assets(@ParentField('address') address: string): Promise<RgbppBaseAsset[]> {
+  public async assets(@ParentField('address') address: string): Promise<RgbppAsset[]> {
     const cells = await this.rgbppAddressService.getRgbppAddressCells(address);
     return cells.map((cell) => RgbppAsset.from(address, cell));
   }
 
-  @ResolveField(() => [Float])
+  @ResolveField(() => [CkbXUDTInfo])
   public async balances(
     @ParentField('address') address: string,
     @Loader(CkbExplorerTransactionLoader) explorerTxLoader: CkbExplorerTransactionLoaderType,

--- a/backend/src/modules/rgbpp/asset/asset.model.ts
+++ b/backend/src/modules/rgbpp/asset/asset.model.ts
@@ -1,11 +1,6 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import { BitcoinOutput } from 'src/modules/bitcoin/output/output.model';
-import { CkbBaseCell, CkbCell } from 'src/modules/ckb/cell/cell.model';
+import { CkbCell } from 'src/modules/ckb/cell/cell.model';
 import * as CkbRpc from 'src/core/ckb-rpc/ckb-rpc.interface';
-
-export type RgbppBaseAsset = Pick<RgbppAsset, 'owner'> & {
-  cell: CkbBaseCell;
-};
 
 @ObjectType({ description: 'Rgbpp Asset' })
 export class RgbppAsset {
@@ -15,10 +10,7 @@ export class RgbppAsset {
   @Field(() => CkbCell)
   cell: CkbCell;
 
-  @Field(() => BitcoinOutput, { nullable: true })
-  utxo: BitcoinOutput | null;
-
-  public static from(address: string, cell: CkbRpc.Cell): RgbppBaseAsset {
+  public static from(address: string, cell: CkbRpc.Cell): RgbppAsset {
     return {
       owner: address,
       cell: CkbCell.fromCell(cell),

--- a/backend/src/modules/rgbpp/asset/asset.resolver.ts
+++ b/backend/src/modules/rgbpp/asset/asset.resolver.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Parent, ResolveField } from '@nestjs/graphql';
 import { BitcoinBaseOutput, BitcoinOutput } from 'src/modules/bitcoin/output/output.model';
-import { RgbppBaseAsset } from './asset.model';
+import { RgbppAsset } from './asset.model';
 import {
   BitcoinTransactionLoader,
   BitcoinTransactionLoaderType,
@@ -15,7 +15,7 @@ export class AssetResolver {
 
   @ResolveField(() => BitcoinOutput, { nullable: true })
   public async utxo(
-    @Parent() asset: RgbppBaseAsset,
+    @Parent() asset: RgbppAsset,
     @Loader(BitcoinTransactionLoader) txLoader: BitcoinTransactionLoaderType,
   ): Promise<BitcoinBaseOutput | null> {
     try {

--- a/backend/src/modules/rgbpp/coin/coin.model.ts
+++ b/backend/src/modules/rgbpp/coin/coin.model.ts
@@ -2,9 +2,6 @@ import { toNumber } from 'lodash';
 import { Field, Float, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { CkbScript } from 'src/modules/ckb/script/script.model';
 import * as CkbExplorer from 'src/core/ckb-explorer/ckb-explorer.interface';
-import { RgbppTransaction } from '../transaction/transaction.model';
-
-export type RgbppBaseCoin = Omit<RgbppCoin, 'transactions' | 'transactionsCount'>;
 
 registerEnumType(CkbExplorer.TransactionListSortType, {
   name: 'TransactionListSortType',
@@ -48,13 +45,7 @@ export class RgbppCoin {
   @Field(() => Date)
   deployedAt: Date;
 
-  @Field(() => [RgbppTransaction], { nullable: true })
-  transactions: RgbppTransaction[] | null;
-
-  @Field(() => Float, { nullable: true })
-  transactionsCount: number | null;
-
-  public static from(xudt: CkbExplorer.XUDT): RgbppBaseCoin | null {
+  public static from(xudt: CkbExplorer.XUDT): RgbppCoin | null {
     if (!xudt) {
       return null;
     }
@@ -78,7 +69,7 @@ export class RgbppCoin {
 @ObjectType({ description: 'RGB++ Coin List' })
 export class RgbppCoinList {
   @Field(() => [RgbppCoin])
-  coins: RgbppBaseCoin[];
+  coins: RgbppCoin[];
 
   @Field(() => Int)
   total: number;

--- a/backend/src/modules/rgbpp/coin/coin.resolver.ts
+++ b/backend/src/modules/rgbpp/coin/coin.resolver.ts
@@ -1,8 +1,8 @@
 import { Args, Float, Int, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CkbExplorerService } from 'src/core/ckb-explorer/ckb-explorer.service';
 import { TransactionListSortType, XUDTTag } from 'src/core/ckb-explorer/ckb-explorer.interface';
-import { RgbppBaseTransaction, RgbppTransaction } from '../transaction/transaction.model';
-import { RgbppBaseCoin, RgbppCoin, RgbppCoinList } from './coin.model';
+import { RgbppTransaction } from '../transaction/transaction.model';
+import { RgbppCoin, RgbppCoinList } from './coin.model';
 import { Loader } from '@applifting-io/nestjs-dataloader';
 import {
   CkbExplorerXUDTTransactionsLoader,
@@ -39,18 +39,18 @@ export class RgbppCoinResolver {
   @Query(() => RgbppCoin, { name: 'rgbppCoin', nullable: true })
   public async coin(
     @Args('typeHash', { type: () => String }) typeHash: string,
-  ): Promise<RgbppBaseCoin | null> {
+  ): Promise<RgbppCoin | null> {
     const response = await this.ckbExplorerService.getXUDT(typeHash);
     return RgbppCoin.from(response.data.attributes);
   }
 
   @ResolveField(() => [RgbppTransaction], { nullable: true })
   public async transactions(
-    @Parent() coin: RgbppBaseCoin,
+    @Parent() coin: RgbppCoin,
     @Args('page', { type: () => Int, nullable: true }) page: number = 1,
     @Args('pageSize', { type: () => Int, nullable: true }) pageSize: number = 10,
     @Loader(CkbExplorerXUDTTransactionsLoader) txsLoader: CkbExplorerXUDTTransactionsLoaderType,
-  ): Promise<RgbppBaseTransaction[] | null> {
+  ): Promise<RgbppTransaction[] | null> {
     if (!coin.typeHash) {
       return null;
     }
@@ -67,7 +67,7 @@ export class RgbppCoinResolver {
 
   @ResolveField(() => Float, { nullable: true })
   public async transactionsCount(
-    @Parent() coin: RgbppBaseCoin,
+    @Parent() coin: RgbppCoin,
     @Loader(CkbExplorerXUDTTransactionsLoader) txsLoader: CkbExplorerXUDTTransactionsLoaderType,
   ): Promise<number | null> {
     if (!coin.typeHash) {

--- a/backend/src/modules/rgbpp/statistic/statistic.model.ts
+++ b/backend/src/modules/rgbpp/statistic/statistic.model.ts
@@ -1,12 +1,4 @@
-import { Field, ObjectType } from '@nestjs/graphql';
-
-export type RgbppBaseStatistic = Record<string, never>;
+import { ObjectType } from '@nestjs/graphql';
 
 @ObjectType({ description: 'RGB++ Coin' })
-export class RgbppStatistic {
-  @Field(() => Number)
-  transactionsCount: number;
-
-  @Field(() => Number)
-  holdersCount: number;
-}
+export class RgbppStatistic {}

--- a/backend/src/modules/rgbpp/statistic/statistic.resolver.ts
+++ b/backend/src/modules/rgbpp/statistic/statistic.resolver.ts
@@ -1,6 +1,6 @@
 import { Float, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { CkbExplorerService } from 'src/core/ckb-explorer/ckb-explorer.service';
-import { RgbppBaseStatistic, RgbppStatistic } from './statistic.model';
+import { RgbppStatistic } from './statistic.model';
 import { RgbppStatisticService } from './statistic.service';
 
 @Resolver(() => RgbppStatistic)
@@ -11,7 +11,7 @@ export class RgbppStatisticResolver {
   ) {}
 
   @Query(() => RgbppStatistic, { name: 'rgbppStatistic' })
-  public async getRgbppStatistic(): Promise<RgbppBaseStatistic> {
+  public async getRgbppStatistic(): Promise<RgbppStatistic> {
     return {};
   }
 

--- a/backend/src/modules/rgbpp/transaction/transaction.dataloader.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.dataloader.ts
@@ -3,11 +3,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import { NestDataLoader } from '@applifting-io/nestjs-dataloader';
 import { DataLoaderResponse } from 'src/common/type/dataloader';
 import { RgbppTransactionService } from './transaction.service';
-import { RgbppBaseTransaction } from './transaction.model';
+import { RgbppTransaction } from './transaction.model';
 import { InjectSentry, SentryService } from '@ntegral/nestjs-sentry';
 
 @Injectable()
-export class RgbppTransactionLoader implements NestDataLoader<string, RgbppBaseTransaction | null> {
+export class RgbppTransactionLoader implements NestDataLoader<string, RgbppTransaction | null> {
   private logger = new Logger(RgbppTransactionLoader.name);
 
   constructor(
@@ -32,5 +32,5 @@ export class RgbppTransactionLoader implements NestDataLoader<string, RgbppBaseT
     };
   }
 }
-export type RgbppTransactionLoaderType = DataLoader<string, RgbppBaseTransaction | null>;
+export type RgbppTransactionLoaderType = DataLoader<string, RgbppTransaction | null>;
 export type RgbppTransactionLoaderResponse = DataLoaderResponse<RgbppTransactionLoader>;

--- a/backend/src/modules/rgbpp/transaction/transaction.model.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.model.ts
@@ -1,15 +1,7 @@
 import { Field, Int, ObjectType, registerEnumType } from '@nestjs/graphql';
 import { toNumber } from 'lodash';
 import * as CkbExplorer from 'src/core/ckb-explorer/ckb-explorer.interface';
-import { BitcoinTransaction } from 'src/modules/bitcoin/transaction/transaction.model';
-import { CkbTransaction } from 'src/modules/ckb/transaction/transaction.model';
 
-export type RgbppBaseTransaction = Omit<
-  RgbppTransaction,
-  'ckbTransaction' | 'btcTransaction' | 'leapDirection'
->;
-
-// XXX: ts-graphql uses enum keys as values in GQL: https://typegraphql.com/docs/enums.html#interoperability
 export enum LeapDirection {
   LeapIn = 'leap_in',
   LeapOut = 'leap_out',
@@ -28,20 +20,11 @@ export class RgbppTransaction {
   @Field(() => String, { nullable: true })
   btcTxid: string | null;
 
-  @Field(() => LeapDirection, { nullable: true })
-  leapDirection: LeapDirection | null;
-
   @Field(() => Int)
   blockNumber: number;
 
   @Field(() => Date)
   timestamp: Date;
-
-  @Field(() => CkbTransaction, { nullable: true })
-  ckbTransaction: CkbTransaction | null;
-
-  @Field(() => BitcoinTransaction, { nullable: true })
-  btcTransaction: BitcoinTransaction | null;
 
   public static from(tx: CkbExplorer.RgbppTransaction) {
     return {
@@ -65,7 +48,7 @@ export class RgbppTransaction {
 @ObjectType({ description: 'RGB++ latest transaction list' })
 export class RgbppLatestTransactionList {
   @Field(() => [RgbppTransaction])
-  txs: RgbppBaseTransaction[];
+  txs: RgbppTransaction[];
 
   @Field(() => Int)
   total: number;

--- a/backend/src/modules/rgbpp/transaction/transaction.resolver.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.resolver.ts
@@ -1,6 +1,6 @@
 import { Loader } from '@applifting-io/nestjs-dataloader';
 import { Args, Int, Parent, Query, ResolveField, Resolver } from '@nestjs/graphql';
-import { CkbBaseTransaction, CkbTransaction } from 'src/modules/ckb/transaction/transaction.model';
+import { CkbTransaction } from 'src/modules/ckb/transaction/transaction.model';
 import {
   CkbRpcTransactionLoader,
   CkbRpcTransactionLoaderType,
@@ -14,20 +14,13 @@ import {
   BitcoinTransactionLoader,
   BitcoinTransactionLoaderType,
 } from 'src/modules/bitcoin/transaction/transaction.dataloader';
-import {
-  RgbppTransaction,
-  RgbppBaseTransaction,
-  RgbppLatestTransactionList,
-  LeapDirection,
-} from './transaction.model';
+import { RgbppTransaction, RgbppLatestTransactionList, LeapDirection } from './transaction.model';
 import { RgbppTransactionLoader, RgbppTransactionLoaderType } from './transaction.dataloader';
 import { HashType, Output } from '@ckb-lumos/lumos';
 
 @Resolver(() => RgbppTransaction)
 export class RgbppTransactionResolver {
-  constructor(
-    private rgbppTransactionService: RgbppTransactionService,
-  ) { }
+  constructor(private rgbppTransactionService: RgbppTransactionService) { }
 
   @Query(() => RgbppLatestTransactionList, { name: 'rgbppLatestTransactions' })
   public async getLatestTransactions(
@@ -41,14 +34,14 @@ export class RgbppTransactionResolver {
   public async getTransaction(
     @Args('txidOrTxHash') txidOrTxHash: string,
     @Loader(RgbppTransactionLoader) txLoader: RgbppTransactionLoaderType,
-  ): Promise<RgbppBaseTransaction | null> {
+  ): Promise<RgbppTransaction | null> {
     const tx = await txLoader.load(txidOrTxHash);
     return tx || null;
   }
 
   @ResolveField(() => LeapDirection, { nullable: true })
   public async leapDirection(
-    @Parent() tx: RgbppBaseTransaction,
+    @Parent() tx: RgbppTransaction,
     @Loader(CkbRpcTransactionLoader) ckbRpcTxLoader: CkbRpcTransactionLoaderType,
   ): Promise<LeapDirection | null> {
     const ckbTx = await ckbRpcTxLoader.load(tx.ckbTxHash);
@@ -60,9 +53,9 @@ export class RgbppTransactionResolver {
 
   @ResolveField(() => CkbTransaction, { nullable: true })
   public async ckbTransaction(
-    @Parent() tx: RgbppBaseTransaction,
+    @Parent() tx: RgbppTransaction,
     @Loader(CkbRpcTransactionLoader) ckbRpcTxLoader: CkbRpcTransactionLoaderType,
-  ): Promise<CkbBaseTransaction | null> {
+  ): Promise<CkbTransaction | null> {
     const ckbTx = await ckbRpcTxLoader.load(tx.ckbTxHash);
     if (!ckbTx) {
       return null;
@@ -72,7 +65,7 @@ export class RgbppTransactionResolver {
 
   @ResolveField(() => BitcoinTransaction, { nullable: true })
   public async btcTransaction(
-    @Parent() tx: RgbppBaseTransaction,
+    @Parent() tx: RgbppTransaction,
     @Loader(BitcoinTransactionLoader) txLoader: BitcoinTransactionLoaderType,
   ): Promise<BitcoinBaseTransaction | null> {
     if (!tx.btcTxid) {

--- a/backend/src/modules/rgbpp/transaction/transaction.service.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.service.ts
@@ -1,12 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { BitcoinApiService } from 'src/core/bitcoin-api/bitcoin-api.service';
 import { CkbExplorerService } from 'src/core/ckb-explorer/ckb-explorer.service';
-import {
-  RgbppTransaction,
-  RgbppBaseTransaction,
-  RgbppLatestTransactionList,
-  LeapDirection,
-} from './transaction.model';
+import { RgbppTransaction, RgbppLatestTransactionList, LeapDirection } from './transaction.model';
 import { ConfigService } from '@nestjs/config';
 import { Env } from 'src/env';
 import { CkbRpcWebsocketService } from 'src/core/ckb-rpc/ckb-rpc-websocket.service';
@@ -28,7 +23,7 @@ export class RgbppTransactionService {
     private rgbppService: RgbppService,
     private bitcoinApiService: BitcoinApiService,
     private configService: ConfigService<Env>,
-  ) {}
+  ) { }
 
   public async getLatestTransactions(
     page: number,
@@ -45,7 +40,7 @@ export class RgbppTransactionService {
     };
   }
 
-  public async getTransactionByCkbTxHash(txHash: string): Promise<RgbppBaseTransaction | null> {
+  public async getTransactionByCkbTxHash(txHash: string): Promise<RgbppTransaction | null> {
     const response = await this.ckbExplorerService.getTransaction(txHash);
     if (!response.data.attributes.is_rgb_transaction) {
       return null;
@@ -53,7 +48,7 @@ export class RgbppTransactionService {
     return RgbppTransaction.fromCkbTransaction(response.data.attributes);
   }
 
-  public async getTransactionByBtcTxid(txid: string): Promise<RgbppBaseTransaction | null> {
+  public async getTransactionByBtcTxid(txid: string): Promise<RgbppTransaction | null> {
     const btcTx = await this.bitcoinApiService.getTx({ txid });
     const tx = (await this.queryRgbppLockTx(btcTx)) ?? (await this.getRgbppBtcTimeLockTx(btcTx));
     if (tx) {
@@ -62,8 +57,8 @@ export class RgbppTransactionService {
     return null;
   }
 
-  public async getTransaction(txidOrTxHash: string): Promise<RgbppBaseTransaction | null> {
-    let tx: RgbppBaseTransaction | null = null;
+  public async getTransaction(txidOrTxHash: string): Promise<RgbppTransaction | null> {
+    let tx: RgbppTransaction | null = null;
     try {
       tx = await this.getTransactionByCkbTxHash(txidOrTxHash);
     } catch (err) {
@@ -92,11 +87,13 @@ export class RgbppTransactionService {
       }),
     );
     const hasRgbppLockInput = inputCells.some(
-      (cell) => cell?.lock && this.rgbppService.isRgbppLockScript({
-        codeHash: cell.lock.code_hash,
-        hashType: cell.lock.hash_type as HashType,
-        args: cell.lock.args,
-      }),
+      (cell) =>
+        cell?.lock &&
+        this.rgbppService.isRgbppLockScript({
+          codeHash: cell.lock.code_hash,
+          hashType: cell.lock.hash_type as HashType,
+          args: cell.lock.args,
+        }),
     );
     const hasRgbppLockOuput = ckbTx.transaction.outputs.some(
       (output) =>

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -32,7 +32,7 @@ type CkbCell {
   type: CkbScript
   lock: CkbScript!
   xudtInfo: CkbXUDTInfo
-  status: CkbCellStatus!
+  status: CkbCellStatus
   cellType: CellType
 }
 
@@ -42,6 +42,21 @@ enum CellType {
   SUDT
   DOB
   MNFT
+}
+
+"""CKB Transaction"""
+type CkbTransaction {
+  isCellbase: Boolean!
+  blockNumber: Float!
+  hash: String!
+  size: Float!
+  outputs: [CkbCell!]!
+  confirmed: Boolean!
+  inputs: [CkbCell!]
+  block: CkbBlock
+  fee: Float
+  feeRate: Float
+  confirmations: Float!
 }
 
 """CKB Address Balance"""
@@ -54,10 +69,10 @@ type CkbAddressBalance {
 """CKB Address"""
 type CkbAddress {
   address: String!
-  shannon: Float!
-  transactionsCount: Float!
-  transactions(page: Float, pageSize: Float): [CkbTransaction!]!
-  balance: CkbAddressBalance!
+  shannon: Float
+  transactionsCount: Float
+  transactions(page: Float, pageSize: Float): [CkbTransaction!]
+  balance: CkbAddressBalance
 }
 
 """CKB Block"""
@@ -68,32 +83,17 @@ type CkbBlock {
   timestamp: Timestamp!
   transactionsCount: Int!
   totalFee: Float
-  miner: CkbAddress!
-  reward: Float!
-  transactions: [CkbTransaction!]!
-  size: Float
-  confirmations: Float
+  miner: CkbAddress
+  reward: Float
+  transactions: [CkbTransaction!]
+  size: Float!
+  confirmations: Float!
 }
 
 """
 `Date` type as integer. Type represents date and time as number of milliseconds from start of UNIX epoch.
 """
 scalar Timestamp
-
-"""CKB Transaction"""
-type CkbTransaction {
-  isCellbase: Boolean!
-  blockNumber: Float!
-  hash: String!
-  fee: Float!
-  feeRate: Float!
-  size: Float!
-  inputs: [CkbCell!]!
-  outputs: [CkbCell!]!
-  block: CkbBlock!
-  confirmed: Boolean!
-  confirmations: Float!
-}
 
 """CKB Fees"""
 type CkbFees {
@@ -109,11 +109,59 @@ type CkbChainInfo {
   fees: CkbFees!
 }
 
-"""Rgbpp Asset"""
-type RgbppAsset {
-  owner: String!
-  cell: CkbCell!
-  utxo: BitcoinOutput
+"""RGB++ Transaction"""
+type RgbppTransaction {
+  ckbTxHash: String!
+  btcTxid: String
+  blockNumber: Int!
+  timestamp: Timestamp!
+  leapDirection: LeapDirection
+  ckbTransaction: CkbTransaction
+  btcTransaction: BitcoinTransaction
+}
+
+enum LeapDirection {
+  LeapIn
+  LeapOut
+  Within
+}
+
+"""RGB++ latest transaction list"""
+type RgbppLatestTransactionList {
+  txs: [RgbppTransaction!]!
+  total: Int!
+  pageSize: Int!
+}
+
+"""RGB++ Coin"""
+type RgbppCoin {
+  name: String
+  description: String
+  symbol: String!
+  decimal: Float!
+  icon: String
+  typeHash: String
+  typeScript: CkbScript
+  holdersCount: Int!
+  h24CkbTransactionsCount: Int!
+  totalAmount: Float!
+  issuer: String!
+  deployedAt: Timestamp!
+  transactions(page: Int, pageSize: Int): [RgbppTransaction!]
+  transactionsCount: Float
+}
+
+"""RGB++ Coin List"""
+type RgbppCoinList {
+  coins: [RgbppCoin!]!
+  total: Int!
+  pageSize: Int!
+}
+
+"""RGB++ Coin"""
+type RgbppStatistic {
+  transactionsCount: Float!
+  holdersCount: Float!
 }
 
 """Rgbpp Address"""
@@ -215,59 +263,10 @@ type BitcoinTransaction {
   rgbppTransaction: RgbppTransaction
 }
 
-"""RGB++ Transaction"""
-type RgbppTransaction {
-  ckbTxHash: String!
-  btcTxid: String
-  leapDirection: LeapDirection
-  blockNumber: Int!
-  timestamp: Timestamp!
-  ckbTransaction: CkbTransaction
-  btcTransaction: BitcoinTransaction
-}
-
-enum LeapDirection {
-  LeapIn
-  LeapOut
-  Within
-}
-
-"""RGB++ latest transaction list"""
-type RgbppLatestTransactionList {
-  txs: [RgbppTransaction!]!
-  total: Int!
-  pageSize: Int!
-}
-
-"""RGB++ Coin"""
-type RgbppCoin {
-  name: String
-  description: String
-  symbol: String!
-  decimal: Float!
-  icon: String
-  typeHash: String
-  typeScript: CkbScript
-  holdersCount: Int!
-  h24CkbTransactionsCount: Int!
-  totalAmount: Float!
-  issuer: String!
-  deployedAt: Timestamp!
-  transactions(page: Int, pageSize: Int): [RgbppTransaction!]
-  transactionsCount: Float
-}
-
-"""RGB++ Coin List"""
-type RgbppCoinList {
-  coins: [RgbppCoin!]!
-  total: Int!
-  pageSize: Int!
-}
-
-"""RGB++ Coin"""
-type RgbppStatistic {
-  transactionsCount: Float!
-  holdersCount: Float!
+"""Rgbpp Asset"""
+type RgbppAsset {
+  owner: String!
+  cell: CkbCell!
 }
 
 """Bitcoin Fees"""


### PR DESCRIPTION
Because the same field in the defined resolver and model will not report an error when the return type is inconsistent, the field that may be null is not nullable in `schema.gql`, and an error will be thrown.

This PR removes the `Base Model` type and directly uses the GraphQL model to represent non-resolve field fields, while other fields are defined and implemented by the resolver so that their query returns are consistent with `schema.gql`.

## GraphQL Schema Diff
![CleanShot 2024-08-08 at 18 11 29](https://github.com/user-attachments/assets/7640a0e7-172c-4013-8731-f496b1cad029)

cc @Vibes-INS 
