### PR TITLE
fix: fix rgbpp transaction timestamp (including L1/L2)

### DIFF
--- a/backend/src/modules/rgbpp/transaction/transaction.model.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.model.ts
@@ -23,15 +23,15 @@ export class RgbppTransaction {
   @Field(() => Int)
   blockNumber: number;
 
-  @Field(() => Date)
-  timestamp: Date;
+  @Field(() => Date, { nullable: true })
+  blockTime: Date | null;
 
   public static from(tx: CkbExplorer.RgbppTransaction) {
     return {
       ckbTxHash: tx.tx_hash,
       btcTxid: tx.rgb_txid,
       blockNumber: tx.block_number,
-      timestamp: new Date(tx.block_timestamp),
+      blockTime: tx.block_timestamp ? new Date(tx.block_timestamp) : null,
     };
   }
 
@@ -40,7 +40,7 @@ export class RgbppTransaction {
       ckbTxHash: tx.transaction_hash,
       btcTxid: tx.is_rgb_transaction ? tx.rgb_txid : null,
       blockNumber: toNumber(tx.block_number),
-      timestamp: new Date(toNumber(tx.create_timestamp)),
+      blockTime: tx.block_timestamp ? new Date(toNumber(tx.block_timestamp)) : null,
     };
   }
 }

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -114,6 +114,7 @@ type RgbppTransaction {
   ckbTxHash: String!
   btcTxid: String
   blockNumber: Int!
+  blockTime: Timestamp
   timestamp: Timestamp!
   leapDirection: LeapDirection
   ckbTransaction: CkbTransaction


### PR DESCRIPTION
Fix the issue that `timestamp` in `RgbppTransaction` may be empty: https://github.com/ckb-cell/utxo-stack-explorer/issues/99#issuecomment-2277206853

This RP adjusts the logic of the `timestamp` in `RgbppTransaction` as follows:
- For an L1 transaction (i.e., when btcTxid is not empty), the timestamp is obtained with the following priority:
  - Creation time of the BTC transaction (retrieved through `getTransactionTimes`)
  - If the CKB transaction is unconfirmed, return the block confirmation time of the BTC transaction.
  - If the CKB transaction is confirmed, return the block confirmation time of the CKB transaction.
- For an L2 transaction
  - If the CKB transaction is unconfirmed, return the time of the CKB transaction added to pool.
  - If the CKB transaction is confirmed, return the block confirmation time of the CKB transaction.

