### PR TITLE
feat: update rgbpp statistic queries

### DIFF
--- a/backend/src/modules/rgbpp/statistic/statistic.resolver.ts
+++ b/backend/src/modules/rgbpp/statistic/statistic.resolver.ts
@@ -1,10 +1,11 @@
-import { Float, Query, ResolveField, Resolver } from '@nestjs/graphql';
+import { Args, Float, Query, ResolveField, Resolver } from '@nestjs/graphql';
 import { RgbppStatistic } from './statistic.model';
 import { RgbppStatisticService } from './statistic.service';
+import { LeapDirection } from '../transaction/transaction.model';
 
 @Resolver(() => RgbppStatistic)
 export class RgbppStatisticResolver {
-  constructor(private rgbppStatisticService: RgbppStatisticService) {}
+  constructor(private rgbppStatisticService: RgbppStatisticService) { }
 
   @Query(() => RgbppStatistic, { name: 'rgbppStatistic' })
   public async getRgbppStatistic(): Promise<RgbppStatistic> {
@@ -23,15 +24,27 @@ export class RgbppStatisticResolver {
     return 0;
   }
 
-  @ResolveField(() => Float)
-  public async latest24HoursL1TransactionsCount(): Promise<number> {
+  @ResolveField(() => Float, { nullable: true })
+  public async latest24HoursL1TransactionsCount(
+    @Args('leapDirection', { type: () => LeapDirection, nullable: true })
+    leapDirection?: LeapDirection,
+  ): Promise<number | null> {
     const txids = await this.rgbppStatisticService.getLatest24L1Transactions();
-    return txids.length;
+    if (txids && leapDirection) {
+      const filteredTxhashs = await Promise.all(
+        txids.map(async (txid) => {
+          const direction = await this.rgbppStatisticService.getLeapDirectionByBtcTxid(txid);
+          return direction === leapDirection ? txid : null;
+        }),
+      );
+      return filteredTxhashs.filter((txhash) => txhash !== null).length;
+    }
+    return txids?.length ?? null;
   }
 
-  @ResolveField(() => Float)
-  public async latest24HoursL2TransactionsCount(): Promise<number> {
+  @ResolveField(() => Float, { nullable: true })
+  public async latest24HoursL2TransactionsCount(): Promise<number | null> {
     const txhashs = await this.rgbppStatisticService.getLatest24L2Transactions();
-    return txhashs.length;
+    return txhashs?.length ?? null;
   }
 }

--- a/backend/src/modules/rgbpp/transaction/transaction.resolver.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.resolver.ts
@@ -103,7 +103,7 @@ export class RgbppTransactionResolver {
     if (!ckbTx) {
       return null;
     }
-    return this.rgbppTransactionService.getLeapDirectionByCkbTx(ckbTx);
+    return this.rgbppTransactionService.getLeapDirectionByCkbTx(ckbTx.transaction);
   }
 
   @ResolveField(() => CkbTransaction, { nullable: true })

--- a/backend/src/modules/rgbpp/transaction/transaction.service.ts
+++ b/backend/src/modules/rgbpp/transaction/transaction.service.ts
@@ -123,13 +123,13 @@ export class RgbppTransactionService {
 
   @Cacheable({
     namespace: 'RgbppTransactionService',
-    key: (tx: CkbRpcInterface.TransactionWithStatusResponse) =>
-      `getLeapDirectionByCkbTx:${tx.transaction.hash}`,
+    key: (tx: CkbRpcInterface.Transaction) =>
+      `getLeapDirectionByCkbTx:${tx.hash}`,
     ttl: ONE_MONTH_MS,
   })
-  public async getLeapDirectionByCkbTx(ckbTx: CkbRpcInterface.TransactionWithStatusResponse) {
+  public async getLeapDirectionByCkbTx(ckbTx: CkbRpcInterface.Transaction) {
     const inputCells = await Promise.all(
-      ckbTx.transaction.inputs.map(async (input) => {
+      ckbTx.inputs.map(async (input) => {
         const inputTx = await this.ckbRpcService.getTransaction(input.previous_output.tx_hash);
         const index = BI.from(input.previous_output.index).toNumber();
         return inputTx?.transaction.outputs?.[index] ?? null;
@@ -144,7 +144,7 @@ export class RgbppTransactionService {
           args: cell.lock.args,
         }),
     );
-    const hasRgbppLockOuput = ckbTx.transaction.outputs.some(
+    const hasRgbppLockOuput = ckbTx.outputs.some(
       (output) =>
         output?.lock &&
         this.rgbppService.isRgbppLockScript({
@@ -153,7 +153,7 @@ export class RgbppTransactionService {
           args: output.lock.args,
         }),
     );
-    const hasBtcTimeLockOutput = ckbTx.transaction.outputs.some(
+    const hasBtcTimeLockOutput = ckbTx.outputs.some(
       (output) =>
         output.lock &&
         this.rgbppService.isBtcTimeLockScript({

--- a/backend/src/schema.gql
+++ b/backend/src/schema.gql
@@ -163,8 +163,8 @@ type RgbppCoinList {
 type RgbppStatistic {
   transactionsCount: Float!
   holdersCount: Float!
-  latest24HoursL1TransactionsCount: Float!
-  latest24HoursL2TransactionsCount: Float!
+  latest24HoursL1TransactionsCount(leapDirection: LeapDirection): Float
+  latest24HoursL2TransactionsCount: Float
 }
 
 """Bitcoin Address"""


### PR DESCRIPTION
## Changes
- `rgbppLatestTransactions` change (If the page & pageSize parameter is not used, there is response data change only)
  - rename the old `rgbppLatestTransactions` query to `rgbppLatestL1Transactions`
  - add new `rgbppLatestTransactions` query for get RGB++ latest transactions (including L1/L2 transaction)
- add `leapDirection` argument to `latest24HoursL1TransactionsCount` query to get the number of transactions of different leap directions

```graphql
query {
  rgbppStatistic {
    latest24HoursL1TransactionsCount(leapDirection: LeapIn)
  }
}
```