### PR TITLE
chore(backend): set the shared memory limit in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,6 +71,8 @@ services:
       retries: 5
     volumes:
       - postgres_volume:/var/lib/postgresql/data
+    # set shared memory limit when using docker-compose
+    shm_size: 128mb
     networks:
       - internal
 


### PR DESCRIPTION
Setting the shared memory limit in Docker Compose using shm_size is essential for applications that require more shared memory than the default allocation.

## References
- [How to use `postgres` image](https://hub.docker.com/_/postgres)
```yml
 # set shared memory limit when using docker-compose 
 shm_size: 128mb
```