### PR TITLE
fix: use separate prisma client to process asset cells to avoid prisma transaction timeouts

### DIFF
--- a/backend/src/core/indexer/processor/assets.processor.ts
+++ b/backend/src/core/indexer/processor/assets.processor.ts
@@ -82,15 +82,13 @@ export class IndexerAssetsProcessor extends WorkerHost {
     }
 
     const indexerAssetsService = this.moduleRef.get(IndexerAssetsService);
-    await this.prismaService.$transaction(async (tx) => {
-      const assets = await Promise.all(
-        cells.objects.map(async (cell) => {
-          return indexerAssetsService.processAssetCell(chainId, cell, assetType, tx);
-        }),
-      );
+    const assets = await Promise.all(
+      cells.objects.map(async (cell) => {
+        return indexerAssetsService.processAssetCell(chainId, cell, assetType);
+      }),
+    );
 
-      return assets;
-    });
+    return assets;
   }
 
   private async getLiveCells(job: Job<IndexerAssetsJobData>) {


### PR DESCRIPTION
Each `processAssetCell` call uses a separate Prisma client to avoid timeout caused by long-time prisma transactions.